### PR TITLE
Add vehicle types reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.8.0
+
+### Added
+
+- (PHP SDK) "Vehicle types" reference ([source][vehicle_types_source]). Additional info you can find in issue: [#8]
+- (PHP SDK) Static method `::getVehicleTypes()` to the class `StaticReferencesData`
+
+[#8]:https://github.com/avto-dev/static-references-data/issues/8
+
 ## v2.7.0
 
 ### Added
@@ -57,6 +66,6 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Code a little bit refactored
 
 [gibdd_fines]:https://xn--90adear.xn--p1ai/mens/fines?page=1
-
+[vehicle_types_source]:http://www.consultant.ru/cons/cgi/online.cgi?req=doc&n=313930&base=EXP&from=313930-1669-diff&rnd=14B238716852CBC1B21D464E9F3969CA#005305945620298047
 [keepachangelog]:https://keepachangelog.com/en/1.0.0/
 [semver]:https://semver.org/spec/v2.0.0.html

--- a/data/vehicle_types/vehicle_types.json
+++ b/data/vehicle_types/vehicle_types.json
@@ -1,0 +1,272 @@
+[
+    {
+        "code": 1,
+        "title": "Бортовые",
+        "group_title": "Грузовые автомобили",
+        "group_slug": "trucks"
+    },
+    {
+        "code": 2,
+        "title": "Шасси",
+        "group_title": "Грузовые автомобили",
+        "group_slug": "trucks"
+    },
+    {
+        "code": 3,
+        "title": "Фургоны",
+        "group_title": "Грузовые автомобили",
+        "group_slug": "trucks"
+    },
+    {
+        "code": 4,
+        "title": "Тягачи седельные",
+        "group_title": "Грузовые автомобили",
+        "group_slug": "trucks"
+    },
+    {
+        "code": 5,
+        "title": "Самосвалы",
+        "group_title": "Грузовые автомобили",
+        "group_slug": "trucks"
+    },
+    {
+        "code": 6,
+        "title": "Рефрижераторы",
+        "group_title": "Грузовые автомобили",
+        "group_slug": "trucks"
+    },
+    {
+        "code": 7,
+        "title": "Цистерны",
+        "group_title": "Грузовые автомобили",
+        "group_slug": "trucks"
+    },
+    {
+        "code": 9,
+        "title": "Прочие",
+        "group_title": "Грузовые автомобили",
+        "group_slug": "trucks"
+    },
+    {
+        "code": 21,
+        "title": "Универсал",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 22,
+        "title": "Комби (хетчбек)",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 23,
+        "title": "Седан",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 24,
+        "title": "Лимузин",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 25,
+        "title": "Купе",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 26,
+        "title": "Кабриолет",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 27,
+        "title": "Фаэтон",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 28,
+        "title": "Пикап",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 29,
+        "title": "Прочие",
+        "group_title": "Легковые автомобили",
+        "group_slug": "cars"
+    },
+    {
+        "code": 41,
+        "title": "Длиной не более 5 м",
+        "group_title": "Автобусы",
+        "group_slug": "buses"
+    },
+    {
+        "code": 42,
+        "title": "Длиной более 5 м, но не более 8,0 м",
+        "group_title": "Автобусы",
+        "group_slug": "buses"
+    },
+    {
+        "code": 43,
+        "title": "Длиной более 8 м, но не более 12 м",
+        "group_title": "Автобусы",
+        "group_slug": "buses"
+    },
+    {
+        "code": 44,
+        "title": "Автобусы сочлененные длиной более 12 м",
+        "group_title": "Автобусы",
+        "group_slug": "buses"
+    },
+    {
+        "code": 49,
+        "title": "Автобусы прочие",
+        "group_title": "Автобусы",
+        "group_slug": "buses"
+    },
+    {
+        "code": 51,
+        "title": "Автоцистерны",
+        "group_title": "Специализированные автомобили",
+        "group_slug": "specialized_vehicles"
+    },
+    {
+        "code": 52,
+        "title": "Санитарные",
+        "group_title": "Специализированные автомобили",
+        "group_slug": "specialized_vehicles"
+    },
+    {
+        "code": 53,
+        "title": "Автокраны",
+        "group_title": "Специализированные автомобили",
+        "group_slug": "specialized_vehicles"
+    },
+    {
+        "code": 54,
+        "title": "Заправщики",
+        "group_title": "Специализированные автомобили",
+        "group_slug": "specialized_vehicles"
+    },
+    {
+        "code": 55,
+        "title": "Мастерские",
+        "group_title": "Специализированные автомобили",
+        "group_slug": "specialized_vehicles"
+    },
+    {
+        "code": 56,
+        "title": "Автопогрузчики",
+        "group_title": "Специализированные автомобили",
+        "group_slug": "specialized_vehicles"
+    },
+    {
+        "code": 59,
+        "title": "Прочие",
+        "group_title": "Специализированные автомобили",
+        "group_slug": "specialized_vehicles"
+    },
+    {
+        "code": 71,
+        "title": "Мотоцикл",
+        "group_title": "Мототранспорт",
+        "group_slug": "mototransport"
+    },
+    {
+        "code": 72,
+        "title": "Мотороллер и мотоколяска",
+        "group_title": "Мототранспорт",
+        "group_slug": "mototransport"
+    },
+    {
+        "code": 73,
+        "title": "Мотовелосипеды и мопеды",
+        "group_title": "Мототранспорт",
+        "group_slug": "mototransport"
+    },
+    {
+        "code": 81,
+        "title": "К легковым автомобилям",
+        "group_title": "Прицепы",
+        "group_slug": "trailers"
+    },
+    {
+        "code": 82,
+        "title": "Общего назначения к грузовым автомобилям",
+        "group_title": "Прицепы",
+        "group_slug": "trailers"
+    },
+    {
+        "code": 83,
+        "title": "Прицепы-цистерны",
+        "group_title": "Прицепы",
+        "group_slug": "trailers"
+    },
+    {
+        "code": 84,
+        "title": "Прицепы тракторные",
+        "group_title": "Прицепы",
+        "group_slug": "trailers"
+    },
+    {
+        "code": 85,
+        "title": "Вагоны-дома передвижные",
+        "group_title": "Прицепы",
+        "group_slug": "trailers"
+    },
+    {
+        "code": 86,
+        "title": "Прицепы со специализированными кузовами",
+        "group_title": "Прицепы",
+        "group_slug": "trailers"
+    },
+    {
+        "code": 87,
+        "title": "Трайлеры",
+        "group_title": "Прицепы",
+        "group_slug": "trailers"
+    },
+    {
+        "code": 89,
+        "title": "Прочие",
+        "group_title": "Прицепы",
+        "group_slug": "trailers"
+    },
+    {
+        "code": 91,
+        "title": "С бортовой платформой",
+        "group_title": "Полуприцепы",
+        "group_slug": "semitrailers"
+    },
+    {
+        "code": 92,
+        "title": "Cамосвалы",
+        "group_title": "Полуприцепы",
+        "group_slug": "semitrailers"
+    },
+    {
+        "code": 93,
+        "title": "Фургоны",
+        "group_title": "Полуприцепы",
+        "group_slug": "semitrailers"
+    },
+    {
+        "code": 95,
+        "title": "Цистерны",
+        "group_title": "Полуприцепы",
+        "group_slug": "semitrailers"
+    },
+    {
+        "code": 99,
+        "title": "Прочие",
+        "group_title": "Полуприцепы",
+        "group_slug": "semitrailers"
+    }
+]

--- a/sdk/php/src/StaticReferencesData.php
+++ b/sdk/php/src/StaticReferencesData.php
@@ -102,4 +102,20 @@ class StaticReferencesData
             static::getRootDirectoryPath(sprintf('/data/auto_fines/%s', $file_name))
         );
     }
+
+    /**
+     * Returns static reference named 'vehicle types'.
+     *
+     * @param string $file_name
+     *
+     * @throws Exception
+     *
+     * @return StaticReference
+     */
+    public static function getVehicleTypes($file_name = 'vehicle_types.json')
+    {
+        return new StaticReference(
+            static::getRootDirectoryPath(sprintf('/data/vehicle_types/%s', $file_name))
+        );
+    }
 }

--- a/sdk/php/tests/DataFiles/VehicleTypesDataFileTest.php
+++ b/sdk/php/tests/DataFiles/VehicleTypesDataFileTest.php
@@ -60,7 +60,7 @@ class VehicleTypesDataFileTest extends AbstractDataFilesTest
      */
     protected function getExpectedEntityCount()
     {
-        return 16;
+        return 45;
     }
 
     /**

--- a/sdk/php/tests/DataFiles/VehicleTypesDataFileTest.php
+++ b/sdk/php/tests/DataFiles/VehicleTypesDataFileTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace AvtoDev\StaticReferencesData\Tests\DataFiles;
+
+/**
+ * Class VehicleTypesDataFileTest.
+ *
+ * Vehicle types file test.
+ */
+class VehicleTypesDataFileTest extends AbstractDataFilesTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testFileStricture()
+    {
+        foreach ($this->getReferenceContent() as $item) {
+            $this->assertArrayHasKey('code', $item);
+            $this->assertInternalType('int', $item['code']);
+
+            $this->assertArrayHasKey('title', $item);
+            $this->assertInternalType('string', $item['title']);
+
+            $this->assertArrayHasKey('group_title', $item);
+            $this->assertInternalType('string', $item['group_title']);
+
+            $this->assertArrayHasKey('group_slug', $item);
+            $this->assertInternalType('string', $item['group_slug']);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDirectoryPath()
+    {
+        return $this->getRootDirPath() . '/data/vehicle_types';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFilePath()
+    {
+        return $this->getRootDirPath() . '/data/vehicle_types/vehicle_types.json';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getReferenceContent()
+    {
+        $instance = $this->instance; // PHP 5.6
+
+        return $instance::getVehicleTypes()->getContent();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedEntityCount()
+    {
+        return 16;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getEntities()
+    {
+        return [
+            [
+                'code'       => 22,
+                'title'      => 'Комби (хетчбек)',
+                'group_title'=> 'Легковые автомобили',
+                'group_slug' => 'cars',
+            ],
+            [
+                'code'       => 3,
+                'title'      => 'Фургоны',
+                'group_title'=> 'Грузовые автомобили',
+                'group_slug' => 'trucks',
+            ],
+            [
+                'code'       => 72,
+                'title'      => 'Мотороллер и мотоколяска',
+                'group_title'=> 'Мототранспорт',
+                'group_slug' => 'mototransport',
+            ],
+        ];
+    }
+}

--- a/sdk/php/tests/StaticReferencesDataTest.php
+++ b/sdk/php/tests/StaticReferencesDataTest.php
@@ -197,4 +197,34 @@ class StaticReferencesDataTest extends AbstractTestCase
 
         $instance::getAutoFines('foo bar');
     }
+
+    /**
+     * @return void
+     */
+    public function testGetVehicleTypes()
+    {
+        $instance = $this->instance; // PHP 5.6
+
+        $this->assertEquals(
+            json_decode(
+                file_get_contents($instance::getRootDirectoryPath(
+                    '/data/vehicle_types/vehicle_types.json'
+                )),
+                true
+            ),
+            $instance::getVehicleTypes()->getContent()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetVehicleTypesWithInvalidFileName()
+    {
+        $instance = $this->instance; // PHP 5.6
+
+        $this->expectException(Exception::class);
+
+        $instance::getVehicleTypes('foo bar');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes 

## Description

### Added

- (PHP SDK) "Vehicle types" reference. Additional info you can find in issue: [#8]
- (PHP SDK) Static method `::getVehicleTypes()` to the class `StaticReferencesData`

[#8]:https://github.com/avto-dev/static-references-data/issues/8

Fixes #8

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/static-references-data/blob/master/CHANGELOG.md) file