### PR TITLE
Removed tarampampam/wrappers-php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Removed
 
-Dependency `tarampampam/wrappers-php` because this package was deprecated and removed
+- Dependency `tarampampam/wrappers-php` because this package was deprecated and removed
 
 ## v3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Removed
+
+Dependency `tarampampam/wrappers-php` because this package was deprecated and removed
+
 ## v3.3.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,9 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "tarampampam/wrappers-php": "^1.2 || ~2.0"
+        "ext-json": "*"
     },
     "require-dev": {
-        "ext-json": "*",
         "opis/json-schema": "^1.0.8",
         "phpstan/phpstan": "~0.12.34",
         "phpunit/phpunit": "^8.5.4 || ^9.3"

--- a/sdk/php/src/ReferencesData/StaticReference.php
+++ b/sdk/php/src/ReferencesData/StaticReference.php
@@ -6,8 +6,6 @@ namespace AvtoDev\StaticReferencesData\ReferencesData;
 
 use RuntimeException;
 use InvalidArgumentException;
-use Tarampampam\Wrappers\Json;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 class StaticReference implements StaticReferenceInterface
 {
@@ -66,14 +64,12 @@ class StaticReference implements StaticReferenceInterface
      * @param bool $as_array When TRUE, returned objects will be converted into associative arrays
      * @param int  $options  Bitmask of JSON decode options
      *
-     * @throws JsonEncodeDecodeException
-     *
      * @return array[]|object[]|array<mixed>|object
      */
     public function getData(bool $as_array = true, int $options = 0)
     {
         /** @var mixed[]|object[]|object $data */
-        $data = Json::decode((string) \file_get_contents($this->file_path), $as_array, 512, $options);
+        $data = \json_decode((string) \file_get_contents($this->file_path), $as_array, 512, $options);
 
         return $data;
     }


### PR DESCRIPTION
## Description

Removed dependency `tarampampam/wrappers-php` because this package was deprecated and removed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Unreleased

### Removed

Dependency `tarampampam/wrappers-php` because this package was deprecated and removed